### PR TITLE
[bug 1411077] Fx57 whatsnew, move line break

### DIFF
--- a/ast/firefox/whatsnew_57.lang
+++ b/ast/firefox/whatsnew_57.lang
@@ -21,7 +21,7 @@ Rápidu pa bien
 
 
 # Line break for formatting.
-;This is what you’ve been waiting for<br> — the fastest Firefox ever.
+;This is what you’ve been waiting for — <br>the fastest Firefox ever.
 Esto ye polo que tuviemos esperando,<br>el Firefox más rápìdu del momentu.
 
 

--- a/bg/firefox/whatsnew_57.lang
+++ b/bg/firefox/whatsnew_57.lang
@@ -21,7 +21,7 @@ Firefox е последна версия
 
 
 # Line break for formatting.
-;This is what you’ve been waiting for<br> — the fastest Firefox ever.
-Ето това очаквахте<br> — най-бързият Firefox досега.
+;This is what you’ve been waiting for — <br>the fastest Firefox ever.
+Ето това очаквахте — <br>най-бързият Firefox досега.
 
 

--- a/bs/firefox/whatsnew_57.lang
+++ b/bs/firefox/whatsnew_57.lang
@@ -21,7 +21,7 @@ Brzo za dobro
 
 
 # Line break for formatting.
-;This is what you’ve been waiting for<br> — the fastest Firefox ever.
-Ovo je ono što ste čekali<br> — najbrži Firefox ikad.
+;This is what you’ve been waiting for — <br>the fastest Firefox ever.
+Ovo je ono što ste čekali — <br>najbrži Firefox ikad.
 
 

--- a/cak/firefox/whatsnew_57.lang
+++ b/cak/firefox/whatsnew_57.lang
@@ -21,7 +21,7 @@ Junelïk aninäq
 
 
 # Line break for formatting.
-;This is what you’ve been waiting for<br> — the fastest Firefox ever.
-Ja re' ri jantape' awoyob'en<br> — ri Firefox janila' aninäq.
+;This is what you’ve been waiting for — <br>the fastest Firefox ever.
+Ja re' ri jantape' awoyob'en — <br>ri Firefox janila' aninäq.
 
 

--- a/cs/firefox/whatsnew_57.lang
+++ b/cs/firefox/whatsnew_57.lang
@@ -21,7 +21,7 @@ Prostě rychlý
 
 
 # Line break for formatting.
-;This is what you’ve been waiting for<br> — the fastest Firefox ever.
-Právě na tohle jste čekali<br> — nejrychlejší Firefox všech dob.
+;This is what you’ve been waiting for — <br>the fastest Firefox ever.
+Právě na tohle jste čekali — <br>nejrychlejší Firefox všech dob.
 
 

--- a/cy/firefox/whatsnew_57.lang
+++ b/cy/firefox/whatsnew_57.lang
@@ -21,7 +21,7 @@ Cyflym er lles
 
 
 # Line break for formatting.
-;This is what you’ve been waiting for<br> — the fastest Firefox ever.
-Dyma'r hyn rydych wedi bod yn aros amdano <br> — y Firefox cyflymaf erioed.
+;This is what you’ve been waiting for — <br>the fastest Firefox ever.
+Dyma'r hyn rydych wedi bod yn aros amdano  — <br>y Firefox cyflymaf erioed.
 
 

--- a/da/firefox/whatsnew_57.lang
+++ b/da/firefox/whatsnew_57.lang
@@ -21,7 +21,7 @@ Hurtig, hurtigere
 
 
 # Line break for formatting.
-;This is what you’ve been waiting for<br> — the fastest Firefox ever.
-Dette er, hvad du har ventet på<br> — den hurtigste Firefox nogensinde.
+;This is what you’ve been waiting for — <br>the fastest Firefox ever.
+Dette er, hvad du har ventet på — <br>den hurtigste Firefox nogensinde.
 
 

--- a/dsb/firefox/whatsnew_57.lang
+++ b/dsb/firefox/whatsnew_57.lang
@@ -21,7 +21,7 @@ Malsny za dobre
 
 
 # Line break for formatting.
-;This is what you’ve been waiting for<br> — the fastest Firefox ever.
-Na to sćo cakał<br> - nejmalsnjejšy Firefox wšych casow.
+;This is what you’ve been waiting for — <br>the fastest Firefox ever.
+Na to sćo cakał - <br>nejmalsnjejšy Firefox wšych casow.
 
 

--- a/eo/firefox/whatsnew_57.lang
+++ b/eo/firefox/whatsnew_57.lang
@@ -21,7 +21,7 @@ Bonfare rapida
 
 
 # Line break for formatting.
-;This is what you’ve been waiting for<br> — the fastest Firefox ever.
-Jen tio, kion vi atendis<br> — la ĝisnune plej rapida Firefox.
+;This is what you’ve been waiting for — <br>the fastest Firefox ever.
+Jen tio, kion vi atendis — <br>la ĝisnune plej rapida Firefox.
 
 

--- a/es-AR/firefox/whatsnew_57.lang
+++ b/es-AR/firefox/whatsnew_57.lang
@@ -21,7 +21,7 @@ Rápido para siempre
 
 
 # Line break for formatting.
-;This is what you’ve been waiting for<br> — the fastest Firefox ever.
-Esto es lo que estuvo esperando<br> — el Firefox más rápido del mundo.
+;This is what you’ve been waiting for — <br>the fastest Firefox ever.
+Esto es lo que estuvo esperando — <br>el Firefox más rápido del mundo.
 
 

--- a/es-CL/firefox/whatsnew_57.lang
+++ b/es-CL/firefox/whatsnew_57.lang
@@ -21,7 +21,7 @@ Rápido para siempre
 
 
 # Line break for formatting.
-;This is what you’ve been waiting for<br> — the fastest Firefox ever.
-Esto es lo que estabas esperando<br> — el Firefox más rápido a la fecha.
+;This is what you’ve been waiting for — <br>the fastest Firefox ever.
+Esto es lo que estabas esperando — <br>el Firefox más rápido a la fecha.
 
 

--- a/es-MX/firefox/whatsnew_57.lang
+++ b/es-MX/firefox/whatsnew_57.lang
@@ -21,7 +21,7 @@ Por siempre rápido
 
 
 # Line break for formatting.
-;This is what you’ve been waiting for<br> — the fastest Firefox ever.
-Esto es lo que has estado esperando<br> — el más rápido Firefox hasta ahora.
+;This is what you’ve been waiting for — <br>the fastest Firefox ever.
+Esto es lo que has estado esperando — <br>el más rápido Firefox hasta ahora.
 
 

--- a/et/firefox/whatsnew_57.lang
+++ b/et/firefox/whatsnew_57.lang
@@ -21,7 +21,7 @@ Kiire igavesti,<br> avalikkuse hüvanguks
 
 
 # Line break for formatting.
-;This is what you’ve been waiting for<br> — the fastest Firefox ever.
-Seda oled sa oodanud<br> — kiireimat Firefoxi üldse.
+;This is what you’ve been waiting for — <br>the fastest Firefox ever.
+Seda oled sa oodanud — <br>kiireimat Firefoxi üldse.
 
 

--- a/fa/firefox/whatsnew_57.lang
+++ b/fa/firefox/whatsnew_57.lang
@@ -21,7 +21,7 @@
 
 
 # Line break for formatting.
-;This is what you’ve been waiting for<br> — the fastest Firefox ever.
-این چیزی است که منتظرش بودید<br> — سریع‌ترین فایرفاکس تاکنون.
+;This is what you’ve been waiting for — <br>the fastest Firefox ever.
+این چیزی است که منتظرش بودید — <br>سریع‌ترین فایرفاکس تاکنون.
 
 

--- a/fy-NL/firefox/whatsnew_57.lang
+++ b/fy-NL/firefox/whatsnew_57.lang
@@ -21,7 +21,7 @@ Fluch foar it goede
 
 
 # Line break for formatting.
-;This is what you’ve been waiting for<br> — the fastest Firefox ever.
-Dit is wêr't jo op wacht hawwe<br> – de fluchste Firefox ea.
+;This is what you’ve been waiting for — <br>the fastest Firefox ever.
+Dit is wêr't jo op wacht hawwe – <br>de fluchste Firefox ea.
 
 

--- a/hi-IN/firefox/whatsnew_57.lang
+++ b/hi-IN/firefox/whatsnew_57.lang
@@ -21,7 +21,7 @@ Firefox अद्यतित है
 
 
 # Line break for formatting.
-;This is what you’ve been waiting for<br> — the fastest Firefox ever.
-यही है वो जिसकी आप प्रतीक्षा कर रहे थे<br> — अब तक का सबसे तेज़ Firefox.
+;This is what you’ve been waiting for — <br>the fastest Firefox ever.
+यही है वो जिसकी आप प्रतीक्षा कर रहे थे — <br>अब तक का सबसे तेज़ Firefox.
 
 

--- a/hsb/firefox/whatsnew_57.lang
+++ b/hsb/firefox/whatsnew_57.lang
@@ -21,7 +21,7 @@ Spěšny za dobre
 
 
 # Line break for formatting.
-;This is what you’ve been waiting for<br> — the fastest Firefox ever.
-Na tole sće čakał<br> - najspěšniši Firefox wšěch časow.
+;This is what you’ve been waiting for — <br>the fastest Firefox ever.
+Na tole sće čakał - <br>najspěšniši Firefox wšěch časow.
 
 

--- a/hu/firefox/whatsnew_57.lang
+++ b/hu/firefox/whatsnew_57.lang
@@ -21,7 +21,7 @@ Gyors, a jó célért
 
 
 # Line break for formatting.
-;This is what you’ve been waiting for<br> — the fastest Firefox ever.
-Ez az amire várt<br>– az eddigi leggyorsabb Firefox.
+;This is what you’ve been waiting for — <br>the fastest Firefox ever.
+Ez az amire várt– <br>az eddigi leggyorsabb Firefox.
 
 

--- a/hy-AM/firefox/whatsnew_57.lang
+++ b/hy-AM/firefox/whatsnew_57.lang
@@ -21,7 +21,7 @@ Firefox-ը թարմ է
 
 
 # Line break for formatting.
-;This is what you’ve been waiting for<br> — the fastest Firefox ever.
-Սա այն է, ինչին դուք սպասում էիք<br>—ամենաարագ Firefox-, որ երբևէ եղել է:
+;This is what you’ve been waiting for — <br>the fastest Firefox ever.
+Սա այն է, ինչին դուք սպասում էիք—<br>ամենաարագ Firefox-, որ երբևէ եղել է:
 
 

--- a/ia/firefox/whatsnew_57.lang
+++ b/ia/firefox/whatsnew_57.lang
@@ -21,7 +21,7 @@ Rapide e pro sempre
 
 
 # Line break for formatting.
-;This is what you’ve been waiting for<br> — the fastest Firefox ever.
-Ecce lo que tu attendeva<br> — le Firefox plus rapide de sempre.
+;This is what you’ve been waiting for — <br>the fastest Firefox ever.
+Ecce lo que tu attendeva — <br>le Firefox plus rapide de sempre.
 
 

--- a/it/firefox/whatsnew_57.lang
+++ b/it/firefox/whatsnew_57.lang
@@ -21,7 +21,7 @@ Veloce. Per il bene comune.
 
 
 # Line break for formatting.
-;This is what you’ve been waiting for<br> — the fastest Firefox ever.
+;This is what you’ve been waiting for — <br>the fastest Firefox ever.
 Finalmente è arrivato:<br> Firefox, più veloce che mai.
 
 

--- a/ja/firefox/whatsnew_57.lang
+++ b/ja/firefox/whatsnew_57.lang
@@ -21,7 +21,7 @@
 
 
 # Line break for formatting.
-;This is what you’ve been waiting for<br> — the fastest Firefox ever.
-あなたが待ち望んでいたものがここに<br> — 史上最速の Firefox。
+;This is what you’ve been waiting for — <br>the fastest Firefox ever.
+あなたが待ち望んでいたものがここに — <br>史上最速の Firefox。
 
 

--- a/ka/firefox/whatsnew_57.lang
+++ b/ka/firefox/whatsnew_57.lang
@@ -21,7 +21,7 @@
 
 
 # Line break for formatting.
-;This is what you’ve been waiting for<br> — the fastest Firefox ever.
-ეს არის სწორედ ის, რასაც ელოდით <br> — ყველა დროის უსწრაფესი Firefox.
+;This is what you’ve been waiting for — <br>the fastest Firefox ever.
+ეს არის სწორედ ის, რასაც ელოდით — <br> ყველა დროის უსწრაფესი Firefox.
 
 

--- a/kab/firefox/whatsnew_57.lang
+++ b/kab/firefox/whatsnew_57.lang
@@ -21,7 +21,7 @@ Arurad i lebda
 
 
 # Line break for formatting.
-;This is what you’ve been waiting for<br> — the fastest Firefox ever.
-D anect-a i telliḍ tettraǧuḍ<br> — Firefox arurad i lebda.
+;This is what you’ve been waiting for — <br>the fastest Firefox ever.
+D anect-a i telliḍ tettraǧuḍ — <br>Firefox arurad i lebda.
 
 

--- a/ko/firefox/whatsnew_57.lang
+++ b/ko/firefox/whatsnew_57.lang
@@ -21,7 +21,7 @@ Firefox가 최신 버전 입니다
 
 
 # Line break for formatting.
-;This is what you’ve been waiting for<br> — the fastest Firefox ever.
-여러분들이 기다려 온 <br> — 가장 빠른 Firefox 입니다.
+;This is what you’ve been waiting for — <br>the fastest Firefox ever.
+여러분들이 기다려 온 — <br> 가장 빠른 Firefox 입니다.
 
 

--- a/lo/firefox/whatsnew_57.lang
+++ b/lo/firefox/whatsnew_57.lang
@@ -21,7 +21,7 @@ Firefox ໃໝ່
 
 
 # Line break for formatting.
-;This is what you’ve been waiting for<br> — the fastest Firefox ever.
-ນີ້ຄືສິ່ງທີ່ເຈົ້າລໍຄອຍ<br> -- ບາວເຊີ Firefox ທີ່ໄວທີ່ສຸດເທົ່າທີ່ເຄີຍມີມາ.
+;This is what you’ve been waiting for — <br>the fastest Firefox ever.
+ນີ້ຄືສິ່ງທີ່ເຈົ້າລໍຄອຍ – <br>ບາວເຊີ Firefox ທີ່ໄວທີ່ສຸດເທົ່າທີ່ເຄີຍມີມາ.
 
 

--- a/lt/firefox/whatsnew_57.lang
+++ b/lt/firefox/whatsnew_57.lang
@@ -21,7 +21,7 @@ Sparti ir tauri
 
 
 # Line break for formatting.
-;This is what you’ve been waiting for<br> — the fastest Firefox ever.
+;This is what you’ve been waiting for — <br>the fastest Firefox ever.
 Tai, ko ir laukėte –<br> pati sparčiausia „Firefox“ laida.
 
 

--- a/ms/firefox/whatsnew_57.lang
+++ b/ms/firefox/whatsnew_57.lang
@@ -21,7 +21,7 @@ Pantas selamanya
 
 
 # Line break for formatting.
-;This is what you’ve been waiting for<br> — the fastest Firefox ever.
-Inilah yang anda nantikan<br> — Firefox yang terpantas.
+;This is what you’ve been waiting for — <br>the fastest Firefox ever.
+Inilah yang anda nantikan — <br>Firefox yang terpantas.
 
 

--- a/nb-NO/firefox/whatsnew_57.lang
+++ b/nb-NO/firefox/whatsnew_57.lang
@@ -21,7 +21,7 @@ Raskest til nå
 
 
 # Line break for formatting.
-;This is what you’ve been waiting for<br> — the fastest Firefox ever.
-Dette er hva du har ventet på<br> — den raskeste Firefox noensinne.
+;This is what you’ve been waiting for — <br>the fastest Firefox ever.
+Dette er hva du har ventet på — <br>den raskeste Firefox noensinne.
 
 

--- a/nl/firefox/whatsnew_57.lang
+++ b/nl/firefox/whatsnew_57.lang
@@ -21,7 +21,7 @@ Snel voor het goede
 
 
 # Line break for formatting.
-;This is what you’ve been waiting for<br> — the fastest Firefox ever.
-Hier hebt u op gewacht<br> – de snelste Firefox ooit.
+;This is what you’ve been waiting for — <br>the fastest Firefox ever.
+Hier hebt u op gewacht – <br>de snelste Firefox ooit.
 
 

--- a/nn-NO/firefox/whatsnew_57.lang
+++ b/nn-NO/firefox/whatsnew_57.lang
@@ -21,7 +21,7 @@ Raskast til no
 
 
 # Line break for formatting.
-;This is what you’ve been waiting for<br> — the fastest Firefox ever.
-Dette er det du har venta på<br> — den raskaste Firefox-en til no.
+;This is what you’ve been waiting for — <br>the fastest Firefox ever.
+Dette er det du har venta på — <br>den raskaste Firefox-en til no.
 
 

--- a/pa-IN/firefox/whatsnew_57.lang
+++ b/pa-IN/firefox/whatsnew_57.lang
@@ -21,7 +21,7 @@
 
 
 # Line break for formatting.
-;This is what you’ve been waiting for<br> — the fastest Firefox ever.
-ਇਹ ਹੈ ਜਿਸ ਨੂੰ ਤੁਸੀਂ ਉਡੀਕਦੇ ਸੀ<br> — ਸਭ ਤੋਂ ਤੇਜ਼ ਫਾਇਰਫਾਕਸ।
+;This is what you’ve been waiting for — <br>the fastest Firefox ever.
+ਇਹ ਹੈ ਜਿਸ ਨੂੰ ਤੁਸੀਂ ਉਡੀਕਦੇ ਸੀ — <br>ਸਭ ਤੋਂ ਤੇਜ਼ ਫਾਇਰਫਾਕਸ।
 
 

--- a/pt-PT/firefox/whatsnew_57.lang
+++ b/pt-PT/firefox/whatsnew_57.lang
@@ -21,7 +21,7 @@ Rápido de vez
 
 
 # Line break for formatting.
-;This is what you’ve been waiting for<br> — the fastest Firefox ever.
-Isto é o que você esperava<br> — o Firefox mais rápido de sempre.
+;This is what you’ve been waiting for — <br>the fastest Firefox ever.
+Isto é o que você esperava — <br>o Firefox mais rápido de sempre.
 
 

--- a/sk/firefox/whatsnew_57.lang
+++ b/sk/firefox/whatsnew_57.lang
@@ -21,7 +21,7 @@ Neuveriteľne rýchly
 
 
 # Line break for formatting.
-;This is what you’ve been waiting for<br> — the fastest Firefox ever.
-Na toto ste čakali<br> - najrýchlejší Firefox vôbec.
+;This is what you’ve been waiting for — <br>the fastest Firefox ever.
+Na toto ste čakali - <br>najrýchlejší Firefox vôbec.
 
 

--- a/sl/firefox/whatsnew_57.lang
+++ b/sl/firefox/whatsnew_57.lang
@@ -21,7 +21,7 @@ Hiter za vedno
 
 
 # Line break for formatting.
-;This is what you’ve been waiting for<br> — the fastest Firefox ever.
-To je tisto, na kar ste čakali<br> — najhitrejši Firefox vseh časov.
+;This is what you’ve been waiting for — <br>the fastest Firefox ever.
+To je tisto, na kar ste čakali — <br>najhitrejši Firefox vseh časov.
 
 

--- a/sq/firefox/whatsnew_57.lang
+++ b/sq/firefox/whatsnew_57.lang
@@ -21,7 +21,7 @@ I shpejtë përgjithnjë
 
 
 # Line break for formatting.
-;This is what you’ve been waiting for<br> — the fastest Firefox ever.
-Ky është ai që keni pritur<br> — Firefox-i më shpejtë deri sot.
+;This is what you’ve been waiting for — <br>the fastest Firefox ever.
+Ky është ai që keni pritur — <br>Firefox-i më shpejtë deri sot.
 
 

--- a/sv-SE/firefox/whatsnew_57.lang
+++ b/sv-SE/firefox/whatsnew_57.lang
@@ -21,7 +21,7 @@ Snabbast hittills
 
 
 # Line break for formatting.
-;This is what you’ve been waiting for<br> — the fastest Firefox ever.
-Det här är vad du har väntat på<br> — den snabbaste Firefox hittills.
+;This is what you’ve been waiting for — <br>the fastest Firefox ever.
+Det här är vad du har väntat på — <br>den snabbaste Firefox hittills.
 
 

--- a/ta/firefox/whatsnew_57.lang
+++ b/ta/firefox/whatsnew_57.lang
@@ -21,7 +21,7 @@
 
 
 # Line break for formatting.
-;This is what you’ve been waiting for<br> — the fastest Firefox ever.
-அதிவேக உலாவி பயர்பாஃசு<br> — இதற்காகத்தான் காத்திருந்தீர்கள்.
+;This is what you’ve been waiting for — <br>the fastest Firefox ever.
+அதிவேக உலாவி பயர்பாஃசு — <br>இதற்காகத்தான் காத்திருந்தீர்கள்.
 
 

--- a/tr/firefox/whatsnew_57.lang
+++ b/tr/firefox/whatsnew_57.lang
@@ -21,7 +21,7 @@ Yeni Firefox
 
 
 # Line break for formatting.
-;This is what you’ve been waiting for<br> — the fastest Firefox ever.
-Beklediğin an geldi<br> — Şimdiye kadarki en hızlı Firefox.
+;This is what you’ve been waiting for — <br>the fastest Firefox ever.
+Beklediğin an geldi — <br>Şimdiye kadarki en hızlı Firefox.
 
 

--- a/uk/firefox/whatsnew_57.lang
+++ b/uk/firefox/whatsnew_57.lang
@@ -21,7 +21,7 @@
 
 
 # Line break for formatting.
-;This is what you’ve been waiting for<br> — the fastest Firefox ever.
-Це те, чого ви так чекали<br> — найшвидший Firefox за весь час.
+;This is what you’ve been waiting for — <br>the fastest Firefox ever.
+Це те, чого ви так чекали — <br>найшвидший Firefox за весь час.
 
 


### PR DESCRIPTION
Attn @peiying2 

This updates all the currently completed locales to reposition the line break after the `–` instead of before.

A few exceptions:

- ast uses a comma with the break after so I only updated the original string.
- it uses a colon with the break after so I only updated the original string.
- lt already had the break after the dash so I only updated the original string.

I excluded any locales that haven't yet translated this page so we can hopefully update those files automatically from the bedrock template (see PR https://github.com/mozilla/bedrock/pull/5232). 

If any more locales get added before this can be merged I can update this PR to avoid overwriting them.